### PR TITLE
avoid render hidden select

### DIFF
--- a/assets/javascripts/select_to_select2.js
+++ b/assets/javascripts/select_to_select2.js
@@ -50,8 +50,10 @@ function replaceAllSelect2(){
                 placeholder: "",
             });
         }
-        else if (elements[i].id == 'available_c' || elements[i].id == 'select_c') {
+        // else if (elements[i].id == 'available_c' || elements[i].id == 'select_c') {
+        else if (elements[i].id == 'available_c' || elements[i].id == 'select_c' || elements[i].style.display == 'none') {
             // Avoid to render select columns option, because of the columm is selected by option not selected attribute.
+            // Avoid to render hidden select.
         }
         else {
             // For All Pages


### PR DESCRIPTION
fix issue: hidden select with style "display: none" will be displayed, such as "Author" edit in NewIssue/EditIssue.

still need further fixing: 
after "edit" is click the display propery is unset, now select will be displayed, replaceAllSelect2() should be called.